### PR TITLE
Add Users and patient ids to oauth exchange

### DIFF
--- a/auth_proxy/models/oauth.py
+++ b/auth_proxy/models/oauth.py
@@ -21,8 +21,11 @@ class Client(Base):
     client_id = Column(String, primary_key=True)
     client_secret = Column(String, nullable=False)
 
-    _redirect_uris = Column(Text)
-    _default_scopes = Column(Text)
+    user_id = Column(Integer, ForeignKey('user.id'))
+    user = orm.relationship('User')
+
+    _redirect_uris = Column('redirect_uris', Text)
+    _default_scopes = Column('default_scopes', Text)
 
     @property
     def client_type(self):
@@ -53,6 +56,9 @@ class Grant(Base):
 
     id = Column(Integer, primary_key=True)
 
+    user_id = Column(Integer, ForeignKey('user.id', ondelete='CASCADE'))
+    user = orm.relationship('User')
+
     client_id = Column(String, ForeignKey('client.client_id'),
                        nullable=False)
     client = orm.relationship('Client')
@@ -62,7 +68,7 @@ class Grant(Base):
     redirect_uri = Column(String)
     expires = Column(DateTime)
 
-    _scopes = Column(Text)
+    _scopes = Column('scopes', Text)
 
     def delete(self):
         self.expires = 0
@@ -90,13 +96,16 @@ class Token(Base):
                        nullable=False)
     client = orm.relationship('Client')
 
+    user_id = Column(Integer, ForeignKey('user.id'))
+    user = orm.relationship('User')
+
     # currently only bearer is supported
     token_type = Column(String)
 
     access_token = Column(String, unique=True)
     refresh_token = Column(String, unique=True)
     expires = Column(DateTime)
-    _scopes = Column(Text)
+    _scopes = Column('scopes', Text)
 
     @property
     def scopes(self):

--- a/auth_proxy/models/oauth.py
+++ b/auth_proxy/models/oauth.py
@@ -21,9 +21,6 @@ class Client(Base):
     client_id = Column(String, primary_key=True)
     client_secret = Column(String, nullable=False)
 
-    user_id = Column(Integer, ForeignKey('user.id'))
-    user = orm.relationship('User')
-
     _redirect_uris = Column('redirect_uris', Text)
     _default_scopes = Column('default_scopes', Text)
 
@@ -79,10 +76,6 @@ class Grant(Base):
             return self._scopes.split()
         return []
 
-    @property
-    def user(self):
-        return None
-
 
 class Token(Base):
     """ A bearer token is the final token that could be used by the client.
@@ -112,10 +105,6 @@ class Token(Base):
         if self._scopes:
             return self._scopes.split()
         return []
-
-    @property
-    def user(self):
-        return None
 
     @property
     def interest(self):

--- a/auth_proxy/models/user.py
+++ b/auth_proxy/models/user.py
@@ -15,4 +15,4 @@ class User(Base):
     __tablename__ = 'user'
 
     id = Column(Integer, primary_key=True)
-    username = Column(String, unique=True)
+    patient_id = Column(String)

--- a/auth_proxy/modules.py
+++ b/auth_proxy/modules.py
@@ -24,7 +24,7 @@ class AppModule(Module):
 
         @self.app.before_first_request
         def cb_create_database(*args, **kwargs):  # pylint: disable=unused-variable
-            from auth_proxy.models import Base, oauth
+            from auth_proxy.models import Base, oauth, user
             Base.metadata.create_all(db.engine)
             db.session.commit()
 

--- a/auth_proxy/modules.py
+++ b/auth_proxy/modules.py
@@ -26,6 +26,7 @@ class AppModule(Module):
         def cb_create_database(*args, **kwargs):  # pylint: disable=unused-variable
             from auth_proxy.models import Base, oauth, user
             Base.metadata.create_all(db.engine)
+            db.session.add(user.User(id=1, patient_id='smart-1288992'))
             db.session.commit()
 
     def configure_db(self):

--- a/auth_proxy/services.py
+++ b/auth_proxy/services.py
@@ -9,6 +9,7 @@ from injector import inject
 import requests
 
 from auth_proxy.models.oauth import Client, Grant, Token
+from auth_proxy.models.user import User
 from auth_proxy.proxy import Proxy
 from auth_proxy.proxy.flask import FlaskClient
 from auth_proxy.proxy.requests import RequestsServer
@@ -34,6 +35,7 @@ class OAuthService(object):
         client = Client(
             client_id=client_id,
             client_secret=str(uuid.uuid4()),
+            user=User(patient_id='smart-1288992'),
             _redirect_uris=redirect_uris,
             _default_scopes=scopes,
         )
@@ -52,6 +54,19 @@ class OAuthService(object):
         """
         return self.db.session.query(Token).\
             filter_by(client_id=client_id)
+
+    def smart_token_credentials(self, client_id):
+        """ Provide additional credentials required by a SMART token request.
+        """
+        client = self.db.session.query(Client).\
+            filter_by(client_id=client_id).first()
+
+        if client is None:
+            return None
+
+        return {
+            'patient': client.user.patient_id,
+        }
 
     def cb_clientgetter(self, client_id):
         """ OAuth2Provider Client getter.

--- a/auth_proxy/services.py
+++ b/auth_proxy/services.py
@@ -120,6 +120,10 @@ class OAuthService(object):
 
     def cb_tokensetter(self, token, request, *args, **kwargs):
         """ OAuth2Provider Token setter.
+
+        Parameters:
+            token : dict
+            request : oauthlib.Request
         """
         tokens = self.db.session.query(Token).\
             filter_by(client_id=request.client.client_id)

--- a/auth_proxy/views.py
+++ b/auth_proxy/views.py
@@ -27,8 +27,12 @@ def configure_views(app, oauth):
 
     @app.route('/oauth/token', methods=['GET', 'POST'])
     @oauth.token_handler
-    def cb_oauth_token(*args, **kwargs):
-        return None
+    @inject(service=services.OAuthService)
+    def cb_oauth_token(service, *args, **kwargs):
+        client_id = request.form.get('client_id')
+        credentials = service.smart_token_credentials(client_id)
+
+        return credentials
 
     @app.route('/oauth/authorize', methods=['GET', 'POST'])
     @oauth.authorize_handler

--- a/auth_proxy/views.py
+++ b/auth_proxy/views.py
@@ -29,8 +29,11 @@ def configure_views(app, oauth):
     @oauth.token_handler
     @inject(service=services.OAuthService)
     def cb_oauth_token(service, *args, **kwargs):
-        client_id = request.form.get('client_id')
-        credentials = service.smart_token_credentials(client_id)
+        credentials = service.smart_token_credentials(
+            grant_type=request.form.get('grant_type'),
+            code=request.form.get('code'),
+            refresh_token=request.form.get('refresh_token'),
+        )
 
         return credentials
 


### PR DESCRIPTION
Establishes a relationship between Clients and Users, allowing the /oauth/token endpoint to return a patient during a successful exchange.