### PR TITLE
Remove trailing comma

### DIFF
--- a/auth_proxy/views.py
+++ b/auth_proxy/views.py
@@ -81,7 +81,7 @@ def configure_views(app, oauth, csrf):
         url = app.config['API_SERVER'] + '/metadata'
         authorize = url_for('cb_oauth_authorize', _external=True)
         token = url_for('cb_oauth_token', _external=True)
-        register = url_for('oauth_register', _external=True),
+        register = url_for('oauth_register', _external=True)
 
         conformance = service.conformance(url=url,
                                           authorize=authorize,


### PR DESCRIPTION
Trailing comma makes `register` a set, which means that the conformance statement looks like
```
{
    "url": "register",
    "valueUri": [
        "http://portal.dev.syncfor.science:9000/oauth/register"
    ]
}
```

which breaks the fhirclient.