### PR TITLE
Whitelist binary resources

### DIFF
--- a/auth_proxy/proxy/flask.py
+++ b/auth_proxy/proxy/flask.py
@@ -21,6 +21,7 @@ class FlaskClient(Client):
     allowed_resources = [
         'metadata',
         'AllergyIntolerance',
+        'Binary',
         'Condition',
         'DocumentReference',
         'Encounter',

--- a/auth_proxy/proxy/requests.py
+++ b/auth_proxy/proxy/requests.py
@@ -23,7 +23,7 @@ class RequestsServer(Server):
                    if key in ALLOWED_HEADERS}
 
         return {
-            'response': response.text,
+            'response': response.content,
             'status': response.status_code,
             'headers': headers,
         }


### PR DESCRIPTION
Fixes https://github.com/sync-for-science/tracking/issues/55.

I was able to put a file directly to the FHIR api, and then I can request it back with the json content type.

```
curl -X GET http://smart.dev.syncfor.science:9000/api/open-fhir/Binary/example-123 --header "Accept: application/json"
```

It hangs when I request it without the content type, but I'm not sure if that's a flask or a uwsgi thing.