### PR TITLE
When setting a token, delete all existing tokens for the client with …

### DIFF
--- a/auth_proxy/services/oauth.py
+++ b/auth_proxy/services/oauth.py
@@ -210,10 +210,15 @@ class OAuthService(object):
         Parameters:
             token : dict
             request : oauthlib.Request
+
+        Retrieve all unexpired tokens, and update the one with the latest
+        approval expiration time; delete the remainder. See
+        https://github.com/sync-for-science/auth-proxy/issues/45 for details.
         """
         assert request.user is not None
 
         today = arrow.now().datetime
+
         old_tokens = self.db.session.query(Token).\
             filter_by(client_id=request.client.client_id).\
             filter(Token.approval_expires >= today).\
@@ -225,7 +230,6 @@ class OAuthService(object):
         for old in old_tokens:
             self.db.session.delete(old)
 
-        self.db.session.delete(old)
         self.db.session.add(new)
         self.db.session.commit()
 


### PR DESCRIPTION
…unexpired approvals, instead of just one

#45 