### PR TITLE
Patch OAuth2Provider's server to remove OpenID handling

### DIFF
--- a/auth_proxy/extensions.py
+++ b/auth_proxy/extensions.py
@@ -5,8 +5,8 @@ To avoid circular imports with views and create_app(), extensions are
 instantiated here. They will be initialized (calling init_app()) in
 application.py.
 """
+from auth_proxy.oauth2 import PatchedOAuth2Provider
 from flask_login import LoginManager
-from flask_oauthlib.provider import OAuth2Provider
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CsrfProtect
 
@@ -14,4 +14,4 @@ from flask_wtf.csrf import CsrfProtect
 db = SQLAlchemy()
 csrf = CsrfProtect()
 login_manager = LoginManager()
-oauthlib = OAuth2Provider()
+oauthlib = PatchedOAuth2Provider()

--- a/auth_proxy/oauth2.py
+++ b/auth_proxy/oauth2.py
@@ -1,0 +1,25 @@
+"""OAuth2 provider patched here.
+
+The provider that comes with flask_oauthlib enables OpenID Connect, but we
+don't want to support that in this application.
+"""
+from flask_oauthlib.provider import OAuth2Provider
+
+
+class PatchedOAuth2Provider(OAuth2Provider):
+    """Patched version of the OAuth2Provider class."""
+    @property
+    def server(self):
+        """The default implementation returns a Server endpoint (oauthlib)
+        whose handler for the `code` response type delegates to either the
+        "vanilla" authorization code workflow or the OIDC workflow, depending
+        on the scopes present in the request. This function modifies the
+        returned Server to use only the "vanilla" grant workflow instead.
+        """
+        server = super().server
+
+        # the handler for the `none` response type does not attempt OIDC
+        auth_grant = server.response_types['none']
+        server.response_types['code'] = auth_grant
+
+        return server


### PR DESCRIPTION
Resolves #49.

Patches the authorization code handler to not use the OIDC workflow.