### PR TITLE
Update pyYAML to 3.13 (fixes build error with python 3.7)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ py==1.4.31
 pylint==1.6.4
 pytest==3.0.5
 python-dateutil==2.6.0
-PyYAML==3.12
+PyYAML==3.13
 requests==2.12.4
 requests-oauthlib==0.7.0
 six==1.10.0


### PR DESCRIPTION
[No changes in functionality between 3.12 and 3.13.](https://github.com/yaml/pyyaml/blob/3.13/CHANGES)